### PR TITLE
Add crossword puzzle type with interactive grid

### DIFF
--- a/docs/assets/main.js
+++ b/docs/assets/main.js
@@ -3,14 +3,97 @@ const PASSWORD = "kobachi";
 const puzzles = [
     {
         id: 1,
-        title: "仮問 1",
-        prompt: "初めの一歩。雨の気配を感じる言葉を答えてください。",
-        placeholderClue: "ヒント: カタカナ3文字です。",
-        hint: "空から落ちてくるものの音を想像してみましょう。",
-        correctAnswer: "アメ",
+        kind: "crossword",
+        title: "クロスワード仮問",
+        prompt: "SATOR スクエアをテーマにしたクロスワードです。各マスに英字1文字を入力し、Across/Down の設問に沿って埋めてみましょう。",
+        placeholderClue: "ヒント: ラテン語由来の単語で構成されています。",
+        hint: "中央の単語 TENET が水平・垂直ともに同じ文字列になるのがスクエア完成の鍵です。",
+        finalAnswer: "TENET",
+        grid: [
+            ["S", "A", "T", "O", "R"],
+            ["A", "R", "E", "P", "O"],
+            ["T", "E", "N", "E", "T"],
+            ["O", "P", "E", "R", "A"],
+            ["R", "O", "T", "A", "S"],
+        ],
+        acrossClues: [
+            {
+                number: 1,
+                clue: "ラテン語で『種をまく人』を意味する語。",
+                answer: "SATOR",
+                row: 0,
+                col: 0,
+            },
+            {
+                number: 2,
+                clue: "謎めいた固有名。古い解釈では鋤を操る人物名とされます。",
+                answer: "AREPO",
+                row: 1,
+                col: 0,
+            },
+            {
+                number: 3,
+                clue: "『保持する』の意を持つラテン語の動詞。",
+                answer: "TENET",
+                row: 2,
+                col: 0,
+            },
+            {
+                number: 4,
+                clue: "ラテン語で『仕事・作品』を表す語。",
+                answer: "OPERA",
+                row: 3,
+                col: 0,
+            },
+            {
+                number: 5,
+                clue: "『車輪』を意味する語。語順を逆転すると最初の語に戻ります。",
+                answer: "ROTAS",
+                row: 4,
+                col: 0,
+            },
+        ],
+        downClues: [
+            {
+                number: 1,
+                clue: "縦読みでも『種まく人』となる語。",
+                answer: "SATOR",
+                row: 0,
+                col: 0,
+            },
+            {
+                number: 2,
+                clue: "スクエアを縦に読むと現れる謎の固有名。",
+                answer: "AREPO",
+                row: 0,
+                col: 1,
+            },
+            {
+                number: 3,
+                clue: "中央列に現れるパリンドローム。",
+                answer: "TENET",
+                row: 0,
+                col: 2,
+            },
+            {
+                number: 4,
+                clue: "縦読みでも『作品』を示す語。",
+                answer: "OPERA",
+                row: 0,
+                col: 3,
+            },
+            {
+                number: 5,
+                clue: "最下段まで伸びる『車輪』の語。",
+                answer: "ROTAS",
+                row: 0,
+                col: 4,
+            },
+        ],
     },
     {
         id: 2,
+        kind: "text",
         title: "仮問 2",
         prompt: "続くのは静かなつなぎの一文字。",
         placeholderClue: "ヒント: ひらがな1文字。",
@@ -19,6 +102,7 @@ const puzzles = [
     },
     {
         id: 3,
+        kind: "text",
         title: "仮問 3",
         prompt: "最後は初夏を彩る花の名を。",
         placeholderClue: "ヒント: カタカナ4文字です。",
@@ -39,6 +123,7 @@ const state = {
     submittedAnswers: [],
     feedback: null,
     revealedHints: new Set(),
+    crosswordProgress: new Map(),
 };
 function resetFeedback() {
     state.feedback = null;
@@ -48,6 +133,7 @@ function resetSession() {
     state.currentPuzzleIndex = 0;
     state.submittedAnswers = [];
     state.revealedHints = new Set();
+    state.crosswordProgress = new Map();
     resetFeedback();
 }
 function render() {
@@ -59,7 +145,13 @@ function render() {
         renderFinal();
         return;
     }
-    renderPuzzle();
+    const current = puzzles[state.currentPuzzleIndex];
+    if (current.kind === "crossword") {
+        renderCrosswordPuzzle(current);
+    }
+    else {
+        renderTextPuzzle(current);
+    }
 }
 function renderLogin() {
     app.innerHTML = `
@@ -102,37 +194,41 @@ function renderLogin() {
         }
     });
 }
-function renderPuzzle() {
-    const current = puzzles[state.currentPuzzleIndex];
-    const hintRevealed = state.revealedHints.has(current.id);
-    const progressIndicators = puzzles
+function buildProgressIndicators() {
+    return puzzles
         .map((puzzle, index) => {
         const isActive = index <= state.currentPuzzleIndex;
         const activeClass = isActive ? "active" : "";
         return `<div class="progress-step ${activeClass}" data-step="${puzzle.id}"></div>`;
     })
         .join("");
+}
+function renderTextPuzzle(puzzle) {
+    const hintRevealed = state.revealedHints.has(puzzle.id);
+    const progressIndicators = buildProgressIndicators();
     const feedbackHtml = state.feedback
         ? `<div class="feedback feedback--${state.feedback.kind}">${state.feedback.message}</div>`
         : "";
-    const hintButtonAttrs = hintRevealed ? "id=\"hint-button\" type=\"button\" disabled" : "id=\"hint-button\" type=\"button\"";
-    const hintText = hintRevealed ? current.hint : "ヒントはまだ非公開です。";
+    const hintButtonAttrs = hintRevealed
+        ? "id=\"hint-button\" type=\"button\" disabled"
+        : "id=\"hint-button\" type=\"button\"";
+    const hintText = hintRevealed ? puzzle.hint : "ヒントはまだ非公開です。";
     const hintClass = hintRevealed ? "hint hint--visible" : "hint";
     app.innerHTML = `
     <section class="app-shell">
       <h1>Hydrangea Riddles</h1>
       <div class="progress">${progressIndicators}</div>
       <div class="puzzle-card">
-        <h2>${current.title}</h2>
-        <p>${current.prompt}</p>
-        <p><em>${current.placeholderClue}</em></p>
+        <h2>${puzzle.title}</h2>
+        <p>${puzzle.prompt}</p>
+        <p><em>${puzzle.placeholderClue}</em></p>
         <div class="hint-row">
           <button ${hintButtonAttrs}>ヒントを見る</button>
           <div id="hint-area" class="${hintClass}">${hintText}</div>
         </div>
-        <label for="answer-input-${current.id}">回答</label>
+        <label for="answer-input-${puzzle.id}">回答</label>
         <input
-          id="answer-input-${current.id}"
+          id="answer-input-${puzzle.id}"
           type="text"
           placeholder="ここに回答を入力"
           autocomplete="off"
@@ -142,7 +238,7 @@ function renderPuzzle() {
       </div>
     </section>
   `;
-    const answerInput = document.getElementById(`answer-input-${current.id}`);
+    const answerInput = document.getElementById(`answer-input-${puzzle.id}`);
     const submitButton = document.getElementById("answer-submit");
     const hintButton = document.getElementById("hint-button");
     const hintArea = document.getElementById("hint-area");
@@ -156,7 +252,7 @@ function renderPuzzle() {
             render();
             return;
         }
-        if (candidate === current.correctAnswer) {
+        if (candidate === puzzle.correctAnswer) {
             state.submittedAnswers[state.currentPuzzleIndex] = candidate;
             state.currentPuzzleIndex += 1;
             state.feedback = {
@@ -177,9 +273,9 @@ function renderPuzzle() {
         if (hintRevealed) {
             return;
         }
-        state.revealedHints.add(current.id);
+        state.revealedHints.add(puzzle.id);
         if (hintArea instanceof HTMLDivElement) {
-            hintArea.textContent = current.hint;
+            hintArea.textContent = puzzle.hint;
             hintArea.classList.add("hint--visible");
         }
         hintButton === null || hintButton === void 0 ? void 0 : hintButton.setAttribute("disabled", "true");
@@ -193,6 +289,481 @@ function renderPuzzle() {
     });
     answerInput === null || answerInput === void 0 ? void 0 : answerInput.focus();
 }
+function ensureCrosswordProgress(puzzle) {
+    var _a, _b;
+    const existing = state.crosswordProgress.get(puzzle.id);
+    if (existing) {
+        return existing;
+    }
+    const entries = puzzle.grid.map((row) => row.map((cell) => (cell ? "" : null)));
+    const firstEditable = findFirstEditableCell(puzzle);
+    const initialClue = (_b = (_a = puzzle.acrossClues[0]) !== null && _a !== void 0 ? _a : puzzle.downClues[0]) !== null && _b !== void 0 ? _b : null;
+    const progress = {
+        entries,
+        activeCell: firstEditable,
+        activeClue: initialClue
+            ? {
+                direction: puzzle.acrossClues.length > 0 ? "across" : "down",
+                number: initialClue.number,
+            }
+            : null,
+    };
+    state.crosswordProgress.set(puzzle.id, progress);
+    return progress;
+}
+function findFirstEditableCell(puzzle) {
+    for (let row = 0; row < puzzle.grid.length; row += 1) {
+        for (let col = 0; col < puzzle.grid[row].length; col += 1) {
+            if (isCellEditable(puzzle, row, col)) {
+                return { row, col };
+            }
+        }
+    }
+    return null;
+}
+function getClueByNumber(puzzle, direction, number) {
+    const source = direction === "across" ? puzzle.acrossClues : puzzle.downClues;
+    return source.find((clue) => clue.number === number);
+}
+function getActiveClue(puzzle, progress) {
+    if (!progress.activeClue) {
+        return null;
+    }
+    const { direction, number } = progress.activeClue;
+    const clue = getClueByNumber(puzzle, direction, number);
+    if (!clue) {
+        return null;
+    }
+    return { clue, direction };
+}
+function getCellsForClue(puzzle, clue, direction) {
+    const cells = [];
+    for (let index = 0; index < clue.answer.length; index += 1) {
+        const row = direction === "across" ? clue.row : clue.row + index;
+        const col = direction === "across" ? clue.col + index : clue.col;
+        if (!isCellEditable(puzzle, row, col)) {
+            break;
+        }
+        cells.push({ row, col });
+    }
+    return cells;
+}
+function isCellEditable(puzzle, row, col) {
+    var _a;
+    return Boolean((_a = puzzle.grid[row]) === null || _a === void 0 ? void 0 : _a[col]);
+}
+function isClueSolved(puzzle, clue, direction, progress) {
+    const cells = getCellsForClue(puzzle, clue, direction);
+    return cells.every(({ row, col }, index) => {
+        var _a, _b;
+        const entry = progress.entries[row][col];
+        if (entry === null) {
+            return false;
+        }
+        const expected = (_b = (_a = clue.answer[index]) === null || _a === void 0 ? void 0 : _a.toUpperCase()) !== null && _b !== void 0 ? _b : "";
+        return entry.toUpperCase() === expected;
+    });
+}
+function isCrosswordSolved(puzzle, progress) {
+    for (let row = 0; row < puzzle.grid.length; row += 1) {
+        for (let col = 0; col < puzzle.grid[row].length; col += 1) {
+            const solution = puzzle.grid[row][col];
+            if (!solution) {
+                continue;
+            }
+            const entry = progress.entries[row][col];
+            if (!entry || entry.toUpperCase() !== solution.toUpperCase()) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+function computeNumberMap(puzzle) {
+    const map = new Map();
+    const register = (clue) => {
+        var _a;
+        const key = `${clue.row}-${clue.col}`;
+        if (!map.has(key) || ((_a = map.get(key)) !== null && _a !== void 0 ? _a : Number.POSITIVE_INFINITY) > clue.number) {
+            map.set(key, clue.number);
+        }
+    };
+    puzzle.acrossClues.forEach(register);
+    puzzle.downClues.forEach(register);
+    return map;
+}
+function findClueContainingCell(puzzle, position, direction) {
+    const source = direction === "across" ? puzzle.acrossClues : puzzle.downClues;
+    for (const clue of source) {
+        const cells = getCellsForClue(puzzle, clue, direction);
+        if (cells.some((cell) => cell.row === position.row && cell.col === position.col)) {
+            return clue;
+        }
+    }
+    return null;
+}
+function syncActiveClue(progress, puzzle, position) {
+    var _a, _b;
+    const preferredDirection = (_b = (_a = progress.activeClue) === null || _a === void 0 ? void 0 : _a.direction) !== null && _b !== void 0 ? _b : "across";
+    const preferred = findClueContainingCell(puzzle, position, preferredDirection);
+    if (preferred) {
+        progress.activeClue = { direction: preferredDirection, number: preferred.number };
+        return;
+    }
+    const alternateDirection = preferredDirection === "across" ? "down" : "across";
+    const alternate = findClueContainingCell(puzzle, position, alternateDirection);
+    if (alternate) {
+        progress.activeClue = { direction: alternateDirection, number: alternate.number };
+        return;
+    }
+    progress.activeClue = null;
+}
+function moveWithinClue(progress, puzzle, step) {
+    const active = getActiveClue(puzzle, progress);
+    if (!active || !progress.activeCell) {
+        return;
+    }
+    const cells = getCellsForClue(puzzle, active.clue, active.direction);
+    const index = cells.findIndex((cell) => { var _a, _b; return cell.row === ((_a = progress.activeCell) === null || _a === void 0 ? void 0 : _a.row) && cell.col === ((_b = progress.activeCell) === null || _b === void 0 ? void 0 : _b.col); });
+    if (index === -1) {
+        return;
+    }
+    const nextIndex = index + step;
+    if (nextIndex >= 0 && nextIndex < cells.length) {
+        progress.activeCell = { ...cells[nextIndex] };
+        syncActiveClue(progress, puzzle, progress.activeCell);
+    }
+}
+function moveActiveCell(progress, puzzle, deltaRow, deltaCol) {
+    const current = progress.activeCell;
+    if (!current) {
+        const firstEditable = findFirstEditableCell(puzzle);
+        if (firstEditable) {
+            progress.activeCell = firstEditable;
+            syncActiveClue(progress, puzzle, firstEditable);
+        }
+        return;
+    }
+    let nextRow = current.row + deltaRow;
+    let nextCol = current.col + deltaCol;
+    while (nextRow >= 0 &&
+        nextRow < puzzle.grid.length &&
+        nextCol >= 0 &&
+        nextCol < puzzle.grid[nextRow].length) {
+        if (isCellEditable(puzzle, nextRow, nextCol)) {
+            const nextPosition = { row: nextRow, col: nextCol };
+            progress.activeCell = nextPosition;
+            syncActiveClue(progress, puzzle, nextPosition);
+            return;
+        }
+        nextRow += deltaRow;
+        nextCol += deltaCol;
+    }
+}
+function renderCrosswordPuzzle(puzzle) {
+    var _a;
+    const progressIndicators = buildProgressIndicators();
+    const progress = ensureCrosswordProgress(puzzle);
+    const hintRevealed = state.revealedHints.has(puzzle.id);
+    const numbersMap = computeNumberMap(puzzle);
+    const active = getActiveClue(puzzle, progress);
+    const highlightedCells = new Set();
+    if (active) {
+        const cells = getCellsForClue(puzzle, active.clue, active.direction);
+        cells.forEach((cell) => highlightedCells.add(`${cell.row}-${cell.col}`));
+    }
+    const gridHtml = puzzle.grid
+        .map((row, rowIndex) => {
+        const cellsHtml = row
+            .map((cell, colIndex) => {
+            var _a;
+            if (!cell) {
+                return '<div class="crossword-cell crossword-cell--block" role="presentation"></div>';
+            }
+            const key = `${rowIndex}-${colIndex}`;
+            const classes = ["crossword-cell"];
+            if (progress.activeCell &&
+                progress.activeCell.row === rowIndex &&
+                progress.activeCell.col === colIndex) {
+                classes.push("crossword-cell--active");
+            }
+            if (highlightedCells.has(key)) {
+                classes.push("crossword-cell--highlight");
+            }
+            const entry = (_a = progress.entries[rowIndex][colIndex]) !== null && _a !== void 0 ? _a : "";
+            if (entry) {
+                classes.push("crossword-cell--filled");
+            }
+            const numberLabel = numbersMap.get(key);
+            const ariaLabel = numberLabel
+                ? `${numberLabel}番のマス (${rowIndex + 1}行${colIndex + 1}列)`
+                : `${rowIndex + 1}行${colIndex + 1}列`;
+            return `
+            <button
+              type="button"
+              class="${classes.join(" ")}"
+              data-row="${rowIndex}"
+              data-col="${colIndex}"
+              aria-label="${ariaLabel}"
+            >
+              ${numberLabel ? `<span class="crossword-cell__number">${numberLabel}</span>` : ""}
+              <span class="crossword-cell__letter">${entry}</span>
+            </button>
+          `;
+        })
+            .join("");
+        return `<div class="crossword-row">${cellsHtml}</div>`;
+    })
+        .join("");
+    const renderClueList = (direction, clues) => clues
+        .map((clue) => {
+        var _a, _b;
+        const isActive = ((_a = progress.activeClue) === null || _a === void 0 ? void 0 : _a.direction) === direction &&
+            ((_b = progress.activeClue) === null || _b === void 0 ? void 0 : _b.number) === clue.number;
+        const solved = isClueSolved(puzzle, clue, direction, progress);
+        const classes = ["crossword-clue"];
+        if (isActive) {
+            classes.push("crossword-clue--active");
+        }
+        if (solved) {
+            classes.push("crossword-clue--solved");
+        }
+        return `
+          <li class="${classes.join(" ")}" data-direction="${direction}" data-number="${clue.number}">
+            <span class="crossword-clue__number">${clue.number}</span>
+            <span class="crossword-clue__text">${clue.clue}</span>
+          </li>
+        `;
+    })
+        .join("");
+    const feedbackHtml = state.feedback
+        ? `<div class="feedback feedback--${state.feedback.kind}">${state.feedback.message}</div>`
+        : "";
+    const hintButtonAttrs = hintRevealed
+        ? "id=\"hint-button\" type=\"button\" disabled"
+        : "id=\"hint-button\" type=\"button\"";
+    const hintText = hintRevealed ? puzzle.hint : "ヒントはまだ非公開です。";
+    const hintClass = hintRevealed ? "hint hint--visible" : "hint";
+    app.innerHTML = `
+    <section class="app-shell">
+      <h1>Hydrangea Riddles</h1>
+      <div class="progress">${progressIndicators}</div>
+      <div class="puzzle-card">
+        <h2>${puzzle.title}</h2>
+        <p>${puzzle.prompt}</p>
+        <p><em>${puzzle.placeholderClue}</em></p>
+        <div class="hint-row">
+          <button ${hintButtonAttrs}>ヒントを見る</button>
+          <div id="hint-area" class="${hintClass}">${hintText}</div>
+        </div>
+        <div class="crossword-layout">
+          <div class="crossword-grid" role="grid" aria-label="クロスワードの盤面">
+            ${gridHtml}
+          </div>
+          <div class="crossword-side">
+            <div class="crossword-input">
+              <label for="crossword-entry-${puzzle.id}">選択中のマス</label>
+              <input
+                id="crossword-entry-${puzzle.id}"
+                type="text"
+                inputmode="text"
+                autocomplete="off"
+                maxlength="1"
+                placeholder="1文字入力"
+              />
+            </div>
+            <div class="crossword-clues">
+              <div class="crossword-clues__group" data-direction="across">
+                <h3>Across</h3>
+                <ol>
+                  ${renderClueList("across", puzzle.acrossClues)}
+                </ol>
+              </div>
+              <div class="crossword-clues__group" data-direction="down">
+                <h3>Down</h3>
+                <ol>
+                  ${renderClueList("down", puzzle.downClues)}
+                </ol>
+              </div>
+            </div>
+          </div>
+        </div>
+        ${feedbackHtml}
+      </div>
+    </section>
+  `;
+    const entryInput = document.getElementById(`crossword-entry-${puzzle.id}`);
+    const hintButton = document.getElementById("hint-button");
+    const hintArea = document.getElementById("hint-area");
+    if (entryInput) {
+        if (progress.activeCell) {
+            const { row, col } = progress.activeCell;
+            const currentValue = (_a = progress.entries[row][col]) !== null && _a !== void 0 ? _a : "";
+            entryInput.value = currentValue;
+            entryInput.focus();
+            entryInput.select();
+        }
+        else {
+            entryInput.value = "";
+        }
+    }
+    const revealHint = () => {
+        if (hintRevealed) {
+            return;
+        }
+        state.revealedHints.add(puzzle.id);
+        if (hintArea instanceof HTMLDivElement) {
+            hintArea.textContent = puzzle.hint;
+            hintArea.classList.add("hint--visible");
+        }
+        hintButton === null || hintButton === void 0 ? void 0 : hintButton.setAttribute("disabled", "true");
+    };
+    hintButton === null || hintButton === void 0 ? void 0 : hintButton.addEventListener("click", revealHint);
+    const handleCompletion = () => {
+        if (!isCrosswordSolved(puzzle, progress)) {
+            return;
+        }
+        state.submittedAnswers[state.currentPuzzleIndex] = puzzle.finalAnswer;
+        state.currentPuzzleIndex += 1;
+        state.feedback = {
+            kind: "success",
+            message: "全マス正解です！次の問題へ進みましょう。",
+        };
+        render();
+    };
+    const handleInput = (event) => {
+        if (!(event.target instanceof HTMLInputElement)) {
+            return;
+        }
+        if (!progress.activeCell) {
+            event.target.value = "";
+            return;
+        }
+        const rawValue = event.target.value;
+        if (!rawValue) {
+            const { row, col } = progress.activeCell;
+            progress.entries[row][col] = "";
+            resetFeedback();
+            render();
+            return;
+        }
+        const letter = rawValue.slice(-1).toUpperCase();
+        const { row, col } = progress.activeCell;
+        progress.entries[row][col] = letter;
+        event.target.value = letter;
+        moveWithinClue(progress, puzzle, 1);
+        resetFeedback();
+        render();
+        handleCompletion();
+    };
+    const handleKeyDown = (event) => {
+        var _a;
+        if (!progress.activeCell) {
+            return;
+        }
+        if (event.key === "Backspace") {
+            event.preventDefault();
+            const { row, col } = progress.activeCell;
+            const currentValue = (_a = progress.entries[row][col]) !== null && _a !== void 0 ? _a : "";
+            if (currentValue) {
+                progress.entries[row][col] = "";
+            }
+            else {
+                moveWithinClue(progress, puzzle, -1);
+                if (progress.activeCell) {
+                    const previous = progress.activeCell;
+                    progress.entries[previous.row][previous.col] = "";
+                }
+            }
+            resetFeedback();
+            render();
+            return;
+        }
+        const deltas = {
+            ArrowLeft: [0, -1],
+            ArrowRight: [0, 1],
+            ArrowUp: [-1, 0],
+            ArrowDown: [1, 0],
+        };
+        const delta = deltas[event.key];
+        if (delta) {
+            event.preventDefault();
+            moveActiveCell(progress, puzzle, delta[0], delta[1]);
+            resetFeedback();
+            render();
+        }
+    };
+    entryInput === null || entryInput === void 0 ? void 0 : entryInput.addEventListener("input", handleInput);
+    entryInput === null || entryInput === void 0 ? void 0 : entryInput.addEventListener("keydown", handleKeyDown);
+    const handleCellSelection = (row, col) => {
+        var _a, _b, _c, _d;
+        if (!isCellEditable(puzzle, row, col)) {
+            return;
+        }
+        const clickedPosition = { row, col };
+        const sameCell = ((_a = progress.activeCell) === null || _a === void 0 ? void 0 : _a.row) === row && ((_b = progress.activeCell) === null || _b === void 0 ? void 0 : _b.col) === col;
+        let desiredDirection = (_d = (_c = progress.activeClue) === null || _c === void 0 ? void 0 : _c.direction) !== null && _d !== void 0 ? _d : "across";
+        let clue = findClueContainingCell(puzzle, clickedPosition, desiredDirection);
+        if (sameCell) {
+            const alternateDirection = desiredDirection === "across" ? "down" : "across";
+            const alternate = findClueContainingCell(puzzle, clickedPosition, alternateDirection);
+            if (alternate) {
+                desiredDirection = alternateDirection;
+                clue = alternate;
+            }
+        }
+        if (!clue) {
+            const alternateDirection = desiredDirection === "across" ? "down" : "across";
+            const alternate = findClueContainingCell(puzzle, clickedPosition, alternateDirection);
+            if (alternate) {
+                desiredDirection = alternateDirection;
+                clue = alternate;
+            }
+        }
+        progress.activeCell = clickedPosition;
+        if (clue) {
+            progress.activeClue = { direction: desiredDirection, number: clue.number };
+        }
+        else {
+            syncActiveClue(progress, puzzle, clickedPosition);
+        }
+        resetFeedback();
+        render();
+    };
+    const cellButtons = Array.from(document.querySelectorAll(".crossword-cell[data-row]"));
+    cellButtons.forEach((button) => {
+        button.addEventListener("click", () => {
+            const row = Number(button.dataset.row);
+            const col = Number(button.dataset.col);
+            if (Number.isNaN(row) || Number.isNaN(col)) {
+                return;
+            }
+            handleCellSelection(row, col);
+        });
+    });
+    const clueItems = Array.from(document.querySelectorAll(".crossword-clue"));
+    clueItems.forEach((item) => {
+        item.addEventListener("click", () => {
+            const direction = item.dataset.direction;
+            const number = Number(item.dataset.number);
+            if (!direction || Number.isNaN(number)) {
+                return;
+            }
+            const clue = getClueByNumber(puzzle, direction, number);
+            if (!clue) {
+                return;
+            }
+            progress.activeClue = { direction, number };
+            const cells = getCellsForClue(puzzle, clue, direction);
+            if (cells.length > 0) {
+                progress.activeCell = { ...cells[0] };
+            }
+            resetFeedback();
+            render();
+        });
+    });
+    handleCompletion();
+}
 function renderFinal() {
     const combinedAnswer = state.submittedAnswers.join("");
     app.innerHTML = `
@@ -200,7 +771,7 @@ function renderFinal() {
       <h1>最終回答</h1>
       <div class="puzzle-card">
         <p>おめでとうございます！すべての仮問に正解しました。</p>
-        <p>3つの回答をつなげると次の言葉になります。</p>
+        <p>各回答をつなげると次の言葉になります。</p>
         <div class="final-answer">${combinedAnswer}</div>
         <footer>※ 現在は仮問です。本番用の問題に差し替えてもこの合成ロジックを再利用できます。</footer>
       </div>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -185,6 +185,157 @@ button:disabled {
   letter-spacing: 0.12em;
 }
 
+.crossword-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.crossword-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.5rem;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.crossword-row {
+  display: flex;
+  gap: 0.3rem;
+}
+
+.crossword-cell {
+  width: 48px;
+  height: 48px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(15, 23, 42, 0.65);
+  color: #f9fafb;
+  font-size: 1.25rem;
+  font-weight: 600;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-transform: uppercase;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.crossword-cell--block {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.crossword-cell--highlight {
+  background: rgba(148, 197, 204, 0.35);
+}
+
+.crossword-cell--active {
+  border-color: var(--accent-dark);
+  box-shadow: 0 0 0 3px rgba(148, 197, 204, 0.3);
+}
+
+.crossword-cell--filled {
+  background: rgba(37, 99, 235, 0.35);
+}
+
+.crossword-cell__number {
+  position: absolute;
+  top: 4px;
+  left: 6px;
+  font-size: 0.55rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  opacity: 0.85;
+}
+
+.crossword-cell__letter {
+  display: inline-block;
+  transform: translateY(1px);
+}
+
+.crossword-side {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.crossword-input {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.crossword-input input {
+  max-width: 120px;
+  text-align: center;
+  font-size: 1.25rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.crossword-clues {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.crossword-clues__group h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.crossword-clues__group ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.crossword-clue {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.crossword-clue:hover {
+  transform: translateY(-1px);
+  border-color: rgba(148, 197, 204, 0.45);
+}
+
+.crossword-clue__number {
+  font-weight: 700;
+  font-size: 0.95rem;
+  opacity: 0.75;
+}
+
+.crossword-clue__text {
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.crossword-clue--active {
+  background: rgba(148, 197, 204, 0.35);
+  border-color: rgba(148, 197, 204, 0.7);
+}
+
+.crossword-clue--solved {
+  background: rgba(34, 197, 94, 0.25);
+  border-color: rgba(34, 197, 94, 0.45);
+}
+
 @media (max-width: 640px) {
   .app-shell {
     padding: 1.75rem;
@@ -196,5 +347,20 @@ button:disabled {
 
   .hint-row {
     align-items: flex-start;
+  }
+}
+
+@media (min-width: 720px) {
+  .crossword-layout {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+
+  .crossword-grid {
+    flex-shrink: 0;
+  }
+
+  .crossword-side {
+    min-width: 260px;
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,32 @@
-﻿const PASSWORD = "kobachi";
+const PASSWORD = "kobachi";
 
 type FeedbackKind = "error" | "success";
 
-type Puzzle = {
+type CrosswordDirection = "across" | "down";
+
+type CrosswordClue = {
+  number: number;
+  clue: string;
+  answer: string;
+  row: number;
+  col: number;
+};
+
+type CrosswordPuzzle = {
+  kind: "crossword";
+  id: number;
+  title: string;
+  prompt: string;
+  placeholderClue: string;
+  hint: string;
+  finalAnswer: string;
+  grid: (string | null)[][];
+  acrossClues: CrosswordClue[];
+  downClues: CrosswordClue[];
+};
+
+type TextPuzzle = {
+  kind: "text";
   id: number;
   title: string;
   prompt: string;
@@ -11,9 +35,22 @@ type Puzzle = {
   correctAnswer: string;
 };
 
+type Puzzle = CrosswordPuzzle | TextPuzzle;
+
 type Feedback = {
   kind: FeedbackKind;
   message: string;
+};
+
+type GridPosition = {
+  row: number;
+  col: number;
+};
+
+type CrosswordProgress = {
+  entries: (string | null)[][];
+  activeCell: GridPosition | null;
+  activeClue: { direction: CrosswordDirection; number: number } | null;
 };
 
 type AppState = {
@@ -22,19 +59,105 @@ type AppState = {
   submittedAnswers: string[];
   feedback: Feedback | null;
   revealedHints: Set<number>;
+  crosswordProgress: Map<number, CrosswordProgress>;
 };
 
 const puzzles: Puzzle[] = [
   {
     id: 1,
-    title: "仮問 1",
-    prompt: "初めの一歩。雨の気配を感じる言葉を答えてください。",
-    placeholderClue: "ヒント: カタカナ3文字です。",
-    hint: "空から落ちてくるものの音を想像してみましょう。",
-    correctAnswer: "アメ",
+    kind: "crossword",
+    title: "クロスワード仮問",
+    prompt:
+      "SATOR スクエアをテーマにしたクロスワードです。各マスに英字1文字を入力し、Across/Down の設問に沿って埋めてみましょう。",
+    placeholderClue: "ヒント: ラテン語由来の単語で構成されています。",
+    hint:
+      "中央の単語 TENET が水平・垂直ともに同じ文字列になるのがスクエア完成の鍵です。",
+    finalAnswer: "TENET",
+    grid: [
+      ["S", "A", "T", "O", "R"],
+      ["A", "R", "E", "P", "O"],
+      ["T", "E", "N", "E", "T"],
+      ["O", "P", "E", "R", "A"],
+      ["R", "O", "T", "A", "S"],
+    ],
+    acrossClues: [
+      {
+        number: 1,
+        clue: "ラテン語で『種をまく人』を意味する語。",
+        answer: "SATOR",
+        row: 0,
+        col: 0,
+      },
+      {
+        number: 2,
+        clue: "謎めいた固有名。古い解釈では鋤を操る人物名とされます。",
+        answer: "AREPO",
+        row: 1,
+        col: 0,
+      },
+      {
+        number: 3,
+        clue: "『保持する』の意を持つラテン語の動詞。",
+        answer: "TENET",
+        row: 2,
+        col: 0,
+      },
+      {
+        number: 4,
+        clue: "ラテン語で『仕事・作品』を表す語。",
+        answer: "OPERA",
+        row: 3,
+        col: 0,
+      },
+      {
+        number: 5,
+        clue: "『車輪』を意味する語。語順を逆転すると最初の語に戻ります。",
+        answer: "ROTAS",
+        row: 4,
+        col: 0,
+      },
+    ],
+    downClues: [
+      {
+        number: 1,
+        clue: "縦読みでも『種まく人』となる語。",
+        answer: "SATOR",
+        row: 0,
+        col: 0,
+      },
+      {
+        number: 2,
+        clue: "スクエアを縦に読むと現れる謎の固有名。",
+        answer: "AREPO",
+        row: 0,
+        col: 1,
+      },
+      {
+        number: 3,
+        clue: "中央列に現れるパリンドローム。",
+        answer: "TENET",
+        row: 0,
+        col: 2,
+      },
+      {
+        number: 4,
+        clue: "縦読みでも『作品』を示す語。",
+        answer: "OPERA",
+        row: 0,
+        col: 3,
+      },
+      {
+        number: 5,
+        clue: "最下段まで伸びる『車輪』の語。",
+        answer: "ROTAS",
+        row: 0,
+        col: 4,
+      },
+    ],
   },
   {
     id: 2,
+    kind: "text",
     title: "仮問 2",
     prompt: "続くのは静かなつなぎの一文字。",
     placeholderClue: "ヒント: ひらがな1文字。",
@@ -43,6 +166,7 @@ const puzzles: Puzzle[] = [
   },
   {
     id: 3,
+    kind: "text",
     title: "仮問 3",
     prompt: "最後は初夏を彩る花の名を。",
     placeholderClue: "ヒント: カタカナ4文字です。",
@@ -65,6 +189,7 @@ const state: AppState = {
   submittedAnswers: [],
   feedback: null,
   revealedHints: new Set<number>(),
+  crosswordProgress: new Map<number, CrosswordProgress>(),
 };
 
 function resetFeedback(): void {
@@ -76,6 +201,7 @@ function resetSession(): void {
   state.currentPuzzleIndex = 0;
   state.submittedAnswers = [];
   state.revealedHints = new Set<number>();
+  state.crosswordProgress = new Map<number, CrosswordProgress>();
   resetFeedback();
 }
 
@@ -90,7 +216,12 @@ function render(): void {
     return;
   }
 
-  renderPuzzle();
+  const current = puzzles[state.currentPuzzleIndex];
+  if (current.kind === "crossword") {
+    renderCrosswordPuzzle(current);
+  } else {
+    renderTextPuzzle(current);
+  }
 }
 
 function renderLogin(): void {
@@ -138,24 +269,28 @@ function renderLogin(): void {
   });
 }
 
-function renderPuzzle(): void {
-  const current = puzzles[state.currentPuzzleIndex];
-  const hintRevealed = state.revealedHints.has(current.id);
-
-  const progressIndicators = puzzles
+function buildProgressIndicators(): string {
+  return puzzles
     .map((puzzle, index) => {
       const isActive = index <= state.currentPuzzleIndex;
       const activeClass = isActive ? "active" : "";
       return `<div class="progress-step ${activeClass}" data-step="${puzzle.id}"></div>`;
     })
     .join("");
+}
+
+function renderTextPuzzle(puzzle: TextPuzzle): void {
+  const hintRevealed = state.revealedHints.has(puzzle.id);
+  const progressIndicators = buildProgressIndicators();
 
   const feedbackHtml = state.feedback
     ? `<div class="feedback feedback--${state.feedback.kind}">${state.feedback.message}</div>`
     : "";
 
-  const hintButtonAttrs = hintRevealed ? "id=\"hint-button\" type=\"button\" disabled" : "id=\"hint-button\" type=\"button\"";
-  const hintText = hintRevealed ? current.hint : "ヒントはまだ非公開です。";
+  const hintButtonAttrs = hintRevealed
+    ? "id=\"hint-button\" type=\"button\" disabled"
+    : "id=\"hint-button\" type=\"button\"";
+  const hintText = hintRevealed ? puzzle.hint : "ヒントはまだ非公開です。";
   const hintClass = hintRevealed ? "hint hint--visible" : "hint";
 
   app.innerHTML = `
@@ -163,16 +298,16 @@ function renderPuzzle(): void {
       <h1>Hydrangea Riddles</h1>
       <div class="progress">${progressIndicators}</div>
       <div class="puzzle-card">
-        <h2>${current.title}</h2>
-        <p>${current.prompt}</p>
-        <p><em>${current.placeholderClue}</em></p>
+        <h2>${puzzle.title}</h2>
+        <p>${puzzle.prompt}</p>
+        <p><em>${puzzle.placeholderClue}</em></p>
         <div class="hint-row">
           <button ${hintButtonAttrs}>ヒントを見る</button>
           <div id="hint-area" class="${hintClass}">${hintText}</div>
         </div>
-        <label for="answer-input-${current.id}">回答</label>
+        <label for="answer-input-${puzzle.id}">回答</label>
         <input
-          id="answer-input-${current.id}"
+          id="answer-input-${puzzle.id}"
           type="text"
           placeholder="ここに回答を入力"
           autocomplete="off"
@@ -183,7 +318,7 @@ function renderPuzzle(): void {
     </section>
   `;
 
-  const answerInput = document.getElementById(`answer-input-${current.id}`) as HTMLInputElement | null;
+  const answerInput = document.getElementById(`answer-input-${puzzle.id}`) as HTMLInputElement | null;
   const submitButton = document.getElementById("answer-submit");
   const hintButton = document.getElementById("hint-button");
   const hintArea = document.getElementById("hint-area");
@@ -199,7 +334,7 @@ function renderPuzzle(): void {
       return;
     }
 
-    if (candidate === current.correctAnswer) {
+    if (candidate === puzzle.correctAnswer) {
       state.submittedAnswers[state.currentPuzzleIndex] = candidate;
       state.currentPuzzleIndex += 1;
       state.feedback = {
@@ -220,9 +355,9 @@ function renderPuzzle(): void {
     if (hintRevealed) {
       return;
     }
-    state.revealedHints.add(current.id);
+    state.revealedHints.add(puzzle.id);
     if (hintArea instanceof HTMLDivElement) {
-      hintArea.textContent = current.hint;
+      hintArea.textContent = puzzle.hint;
       hintArea.classList.add("hint--visible");
     }
     hintButton?.setAttribute("disabled", "true");
@@ -238,6 +373,557 @@ function renderPuzzle(): void {
 
   answerInput?.focus();
 }
+function ensureCrosswordProgress(puzzle: CrosswordPuzzle): CrosswordProgress {
+  const existing = state.crosswordProgress.get(puzzle.id);
+  if (existing) {
+    return existing;
+  }
+
+  const entries = puzzle.grid.map((row) =>
+    row.map((cell) => (cell ? "" : null))
+  );
+
+  const firstEditable = findFirstEditableCell(puzzle);
+  const initialClue = puzzle.acrossClues[0] ?? puzzle.downClues[0] ?? null;
+
+  const progress: CrosswordProgress = {
+    entries,
+    activeCell: firstEditable,
+    activeClue: initialClue
+      ? {
+          direction: puzzle.acrossClues.length > 0 ? "across" : "down",
+          number: initialClue.number,
+        }
+      : null,
+  };
+
+  state.crosswordProgress.set(puzzle.id, progress);
+  return progress;
+}
+
+function findFirstEditableCell(puzzle: CrosswordPuzzle): GridPosition | null {
+  for (let row = 0; row < puzzle.grid.length; row += 1) {
+    for (let col = 0; col < puzzle.grid[row].length; col += 1) {
+      if (isCellEditable(puzzle, row, col)) {
+        return { row, col };
+      }
+    }
+  }
+  return null;
+}
+
+function getClueByNumber(
+  puzzle: CrosswordPuzzle,
+  direction: CrosswordDirection,
+  number: number,
+): CrosswordClue | undefined {
+  const source = direction === "across" ? puzzle.acrossClues : puzzle.downClues;
+  return source.find((clue) => clue.number === number);
+}
+
+function getActiveClue(
+  puzzle: CrosswordPuzzle,
+  progress: CrosswordProgress,
+): { clue: CrosswordClue; direction: CrosswordDirection } | null {
+  if (!progress.activeClue) {
+    return null;
+  }
+  const { direction, number } = progress.activeClue;
+  const clue = getClueByNumber(puzzle, direction, number);
+  if (!clue) {
+    return null;
+  }
+  return { clue, direction };
+}
+
+function getCellsForClue(
+  puzzle: CrosswordPuzzle,
+  clue: CrosswordClue,
+  direction: CrosswordDirection,
+): GridPosition[] {
+  const cells: GridPosition[] = [];
+  for (let index = 0; index < clue.answer.length; index += 1) {
+    const row = direction === "across" ? clue.row : clue.row + index;
+    const col = direction === "across" ? clue.col + index : clue.col;
+    if (!isCellEditable(puzzle, row, col)) {
+      break;
+    }
+    cells.push({ row, col });
+  }
+  return cells;
+}
+
+function isCellEditable(puzzle: CrosswordPuzzle, row: number, col: number): boolean {
+  return Boolean(puzzle.grid[row]?.[col]);
+}
+
+function isClueSolved(
+  puzzle: CrosswordPuzzle,
+  clue: CrosswordClue,
+  direction: CrosswordDirection,
+  progress: CrosswordProgress,
+): boolean {
+  const cells = getCellsForClue(puzzle, clue, direction);
+  return cells.every(({ row, col }, index) => {
+    const entry = progress.entries[row][col];
+    if (entry === null) {
+      return false;
+    }
+    const expected = clue.answer[index]?.toUpperCase() ?? "";
+    return entry.toUpperCase() === expected;
+  });
+}
+
+function isCrosswordSolved(puzzle: CrosswordPuzzle, progress: CrosswordProgress): boolean {
+  for (let row = 0; row < puzzle.grid.length; row += 1) {
+    for (let col = 0; col < puzzle.grid[row].length; col += 1) {
+      const solution = puzzle.grid[row][col];
+      if (!solution) {
+        continue;
+      }
+      const entry = progress.entries[row][col];
+      if (!entry || entry.toUpperCase() !== solution.toUpperCase()) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+function computeNumberMap(puzzle: CrosswordPuzzle): Map<string, number> {
+  const map = new Map<string, number>();
+  const register = (clue: CrosswordClue): void => {
+    const key = `${clue.row}-${clue.col}`;
+    if (!map.has(key) || (map.get(key) ?? Number.POSITIVE_INFINITY) > clue.number) {
+      map.set(key, clue.number);
+    }
+  };
+
+  puzzle.acrossClues.forEach(register);
+  puzzle.downClues.forEach(register);
+
+  return map;
+}
+
+function findClueContainingCell(
+  puzzle: CrosswordPuzzle,
+  position: GridPosition,
+  direction: CrosswordDirection,
+): CrosswordClue | null {
+  const source = direction === "across" ? puzzle.acrossClues : puzzle.downClues;
+  for (const clue of source) {
+    const cells = getCellsForClue(puzzle, clue, direction);
+    if (cells.some((cell) => cell.row === position.row && cell.col === position.col)) {
+      return clue;
+    }
+  }
+  return null;
+}
+
+function syncActiveClue(
+  progress: CrosswordProgress,
+  puzzle: CrosswordPuzzle,
+  position: GridPosition,
+): void {
+  const preferredDirection = progress.activeClue?.direction ?? "across";
+  const preferred = findClueContainingCell(puzzle, position, preferredDirection);
+  if (preferred) {
+    progress.activeClue = { direction: preferredDirection, number: preferred.number };
+    return;
+  }
+  const alternateDirection = preferredDirection === "across" ? "down" : "across";
+  const alternate = findClueContainingCell(puzzle, position, alternateDirection);
+  if (alternate) {
+    progress.activeClue = { direction: alternateDirection, number: alternate.number };
+    return;
+  }
+  progress.activeClue = null;
+}
+
+function moveWithinClue(
+  progress: CrosswordProgress,
+  puzzle: CrosswordPuzzle,
+  step: number,
+): void {
+  const active = getActiveClue(puzzle, progress);
+  if (!active || !progress.activeCell) {
+    return;
+  }
+  const cells = getCellsForClue(puzzle, active.clue, active.direction);
+  const index = cells.findIndex(
+    (cell) => cell.row === progress.activeCell?.row && cell.col === progress.activeCell?.col,
+  );
+  if (index === -1) {
+    return;
+  }
+  const nextIndex = index + step;
+  if (nextIndex >= 0 && nextIndex < cells.length) {
+    progress.activeCell = { ...cells[nextIndex] };
+    syncActiveClue(progress, puzzle, progress.activeCell);
+  }
+}
+
+function moveActiveCell(
+  progress: CrosswordProgress,
+  puzzle: CrosswordPuzzle,
+  deltaRow: number,
+  deltaCol: number,
+): void {
+  const current = progress.activeCell;
+  if (!current) {
+    const firstEditable = findFirstEditableCell(puzzle);
+    if (firstEditable) {
+      progress.activeCell = firstEditable;
+      syncActiveClue(progress, puzzle, firstEditable);
+    }
+    return;
+  }
+
+  let nextRow = current.row + deltaRow;
+  let nextCol = current.col + deltaCol;
+
+  while (
+    nextRow >= 0 &&
+    nextRow < puzzle.grid.length &&
+    nextCol >= 0 &&
+    nextCol < puzzle.grid[nextRow].length
+  ) {
+    if (isCellEditable(puzzle, nextRow, nextCol)) {
+      const nextPosition = { row: nextRow, col: nextCol };
+      progress.activeCell = nextPosition;
+      syncActiveClue(progress, puzzle, nextPosition);
+      return;
+    }
+    nextRow += deltaRow;
+    nextCol += deltaCol;
+  }
+}
+function renderCrosswordPuzzle(puzzle: CrosswordPuzzle): void {
+  const progressIndicators = buildProgressIndicators();
+  const progress = ensureCrosswordProgress(puzzle);
+  const hintRevealed = state.revealedHints.has(puzzle.id);
+  const numbersMap = computeNumberMap(puzzle);
+  const active = getActiveClue(puzzle, progress);
+
+  const highlightedCells = new Set<string>();
+  if (active) {
+    const cells = getCellsForClue(puzzle, active.clue, active.direction);
+    cells.forEach((cell) => highlightedCells.add(`${cell.row}-${cell.col}`));
+  }
+
+  const gridHtml = puzzle.grid
+    .map((row, rowIndex) => {
+      const cellsHtml = row
+        .map((cell, colIndex) => {
+          if (!cell) {
+            return '<div class="crossword-cell crossword-cell--block" role="presentation"></div>';
+          }
+
+          const key = `${rowIndex}-${colIndex}`;
+          const classes = ["crossword-cell"];
+          if (
+            progress.activeCell &&
+            progress.activeCell.row === rowIndex &&
+            progress.activeCell.col === colIndex
+          ) {
+            classes.push("crossword-cell--active");
+          }
+          if (highlightedCells.has(key)) {
+            classes.push("crossword-cell--highlight");
+          }
+          const entry = progress.entries[rowIndex][colIndex] ?? "";
+          if (entry) {
+            classes.push("crossword-cell--filled");
+          }
+          const numberLabel = numbersMap.get(key);
+          const ariaLabel = numberLabel
+            ? `${numberLabel}番のマス (${rowIndex + 1}行${colIndex + 1}列)`
+            : `${rowIndex + 1}行${colIndex + 1}列`;
+          return `
+            <button
+              type="button"
+              class="${classes.join(" ")}"
+              data-row="${rowIndex}"
+              data-col="${colIndex}"
+              aria-label="${ariaLabel}"
+            >
+              ${numberLabel ? `<span class="crossword-cell__number">${numberLabel}</span>` : ""}
+              <span class="crossword-cell__letter">${entry}</span>
+            </button>
+          `;
+        })
+        .join("");
+      return `<div class="crossword-row">${cellsHtml}</div>`;
+    })
+    .join("");
+
+  const renderClueList = (direction: CrosswordDirection, clues: CrosswordClue[]): string =>
+    clues
+      .map((clue) => {
+        const isActive =
+          progress.activeClue?.direction === direction &&
+          progress.activeClue?.number === clue.number;
+        const solved = isClueSolved(puzzle, clue, direction, progress);
+        const classes = ["crossword-clue"];
+        if (isActive) {
+          classes.push("crossword-clue--active");
+        }
+        if (solved) {
+          classes.push("crossword-clue--solved");
+        }
+        return `
+          <li class="${classes.join(" ")}" data-direction="${direction}" data-number="${clue.number}">
+            <span class="crossword-clue__number">${clue.number}</span>
+            <span class="crossword-clue__text">${clue.clue}</span>
+          </li>
+        `;
+      })
+      .join("");
+
+  const feedbackHtml = state.feedback
+    ? `<div class="feedback feedback--${state.feedback.kind}">${state.feedback.message}</div>`
+    : "";
+
+  const hintButtonAttrs = hintRevealed
+    ? "id=\"hint-button\" type=\"button\" disabled"
+    : "id=\"hint-button\" type=\"button\"";
+  const hintText = hintRevealed ? puzzle.hint : "ヒントはまだ非公開です。";
+  const hintClass = hintRevealed ? "hint hint--visible" : "hint";
+
+  app.innerHTML = `
+    <section class="app-shell">
+      <h1>Hydrangea Riddles</h1>
+      <div class="progress">${progressIndicators}</div>
+      <div class="puzzle-card">
+        <h2>${puzzle.title}</h2>
+        <p>${puzzle.prompt}</p>
+        <p><em>${puzzle.placeholderClue}</em></p>
+        <div class="hint-row">
+          <button ${hintButtonAttrs}>ヒントを見る</button>
+          <div id="hint-area" class="${hintClass}">${hintText}</div>
+        </div>
+        <div class="crossword-layout">
+          <div class="crossword-grid" role="grid" aria-label="クロスワードの盤面">
+            ${gridHtml}
+          </div>
+          <div class="crossword-side">
+            <div class="crossword-input">
+              <label for="crossword-entry-${puzzle.id}">選択中のマス</label>
+              <input
+                id="crossword-entry-${puzzle.id}"
+                type="text"
+                inputmode="text"
+                autocomplete="off"
+                maxlength="1"
+                placeholder="1文字入力"
+              />
+            </div>
+            <div class="crossword-clues">
+              <div class="crossword-clues__group" data-direction="across">
+                <h3>Across</h3>
+                <ol>
+                  ${renderClueList("across", puzzle.acrossClues)}
+                </ol>
+              </div>
+              <div class="crossword-clues__group" data-direction="down">
+                <h3>Down</h3>
+                <ol>
+                  ${renderClueList("down", puzzle.downClues)}
+                </ol>
+              </div>
+            </div>
+          </div>
+        </div>
+        ${feedbackHtml}
+      </div>
+    </section>
+  `;
+
+  const entryInput = document.getElementById(`crossword-entry-${puzzle.id}`) as HTMLInputElement | null;
+  const hintButton = document.getElementById("hint-button");
+  const hintArea = document.getElementById("hint-area");
+
+  if (entryInput) {
+    if (progress.activeCell) {
+      const { row, col } = progress.activeCell;
+      const currentValue = progress.entries[row][col] ?? "";
+      entryInput.value = currentValue;
+      entryInput.focus();
+      entryInput.select();
+    } else {
+      entryInput.value = "";
+    }
+  }
+
+  const revealHint = (): void => {
+    if (hintRevealed) {
+      return;
+    }
+    state.revealedHints.add(puzzle.id);
+    if (hintArea instanceof HTMLDivElement) {
+      hintArea.textContent = puzzle.hint;
+      hintArea.classList.add("hint--visible");
+    }
+    hintButton?.setAttribute("disabled", "true");
+  };
+
+  hintButton?.addEventListener("click", revealHint);
+
+  const handleCompletion = (): void => {
+    if (!isCrosswordSolved(puzzle, progress)) {
+      return;
+    }
+    state.submittedAnswers[state.currentPuzzleIndex] = puzzle.finalAnswer;
+    state.currentPuzzleIndex += 1;
+    state.feedback = {
+      kind: "success",
+      message: "全マス正解です！次の問題へ進みましょう。",
+    };
+    render();
+  };
+
+  const handleInput = (event: Event): void => {
+    if (!(event.target instanceof HTMLInputElement)) {
+      return;
+    }
+    if (!progress.activeCell) {
+      event.target.value = "";
+      return;
+    }
+    const rawValue = event.target.value;
+    if (!rawValue) {
+      const { row, col } = progress.activeCell;
+      progress.entries[row][col] = "";
+      resetFeedback();
+      render();
+      return;
+    }
+    const letter = rawValue.slice(-1).toUpperCase();
+    const { row, col } = progress.activeCell;
+    progress.entries[row][col] = letter;
+    event.target.value = letter;
+    moveWithinClue(progress, puzzle, 1);
+    resetFeedback();
+    render();
+    handleCompletion();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    if (!progress.activeCell) {
+      return;
+    }
+    if (event.key === "Backspace") {
+      event.preventDefault();
+      const { row, col } = progress.activeCell;
+      const currentValue = progress.entries[row][col] ?? "";
+      if (currentValue) {
+        progress.entries[row][col] = "";
+      } else {
+        moveWithinClue(progress, puzzle, -1);
+        if (progress.activeCell) {
+          const previous = progress.activeCell;
+          progress.entries[previous.row][previous.col] = "";
+        }
+      }
+      resetFeedback();
+      render();
+      return;
+    }
+
+    const deltas: Record<string, [number, number]> = {
+      ArrowLeft: [0, -1],
+      ArrowRight: [0, 1],
+      ArrowUp: [-1, 0],
+      ArrowDown: [1, 0],
+    };
+
+    const delta = deltas[event.key];
+    if (delta) {
+      event.preventDefault();
+      moveActiveCell(progress, puzzle, delta[0], delta[1]);
+      resetFeedback();
+      render();
+    }
+  };
+
+  entryInput?.addEventListener("input", handleInput);
+  entryInput?.addEventListener("keydown", handleKeyDown);
+
+  const handleCellSelection = (row: number, col: number): void => {
+    if (!isCellEditable(puzzle, row, col)) {
+      return;
+    }
+    const clickedPosition = { row, col };
+    const sameCell =
+      progress.activeCell?.row === row && progress.activeCell?.col === col;
+    let desiredDirection = progress.activeClue?.direction ?? "across";
+    let clue = findClueContainingCell(puzzle, clickedPosition, desiredDirection);
+    if (sameCell) {
+      const alternateDirection = desiredDirection === "across" ? "down" : "across";
+      const alternate = findClueContainingCell(puzzle, clickedPosition, alternateDirection);
+      if (alternate) {
+        desiredDirection = alternateDirection;
+        clue = alternate;
+      }
+    }
+    if (!clue) {
+      const alternateDirection = desiredDirection === "across" ? "down" : "across";
+      const alternate = findClueContainingCell(puzzle, clickedPosition, alternateDirection);
+      if (alternate) {
+        desiredDirection = alternateDirection;
+        clue = alternate;
+      }
+    }
+    progress.activeCell = clickedPosition;
+    if (clue) {
+      progress.activeClue = { direction: desiredDirection, number: clue.number };
+    } else {
+      syncActiveClue(progress, puzzle, clickedPosition);
+    }
+    resetFeedback();
+    render();
+  };
+
+  const cellButtons = Array.from(
+    document.querySelectorAll<HTMLButtonElement>(".crossword-cell[data-row]"),
+  );
+  cellButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      const row = Number(button.dataset.row);
+      const col = Number(button.dataset.col);
+      if (Number.isNaN(row) || Number.isNaN(col)) {
+        return;
+      }
+      handleCellSelection(row, col);
+    });
+  });
+
+  const clueItems = Array.from(
+    document.querySelectorAll<HTMLLIElement>(".crossword-clue"),
+  );
+  clueItems.forEach((item) => {
+    item.addEventListener("click", () => {
+      const direction = item.dataset.direction as CrosswordDirection | undefined;
+      const number = Number(item.dataset.number);
+      if (!direction || Number.isNaN(number)) {
+        return;
+      }
+      const clue = getClueByNumber(puzzle, direction, number);
+      if (!clue) {
+        return;
+      }
+      progress.activeClue = { direction, number };
+      const cells = getCellsForClue(puzzle, clue, direction);
+      if (cells.length > 0) {
+        progress.activeCell = { ...cells[0] };
+      }
+      resetFeedback();
+      render();
+    });
+  });
+
+  handleCompletion();
+}
 
 function renderFinal(): void {
   const combinedAnswer = state.submittedAnswers.join("");
@@ -247,7 +933,7 @@ function renderFinal(): void {
       <h1>最終回答</h1>
       <div class="puzzle-card">
         <p>おめでとうございます！すべての仮問に正解しました。</p>
-        <p>3つの回答をつなげると次の言葉になります。</p>
+        <p>各回答をつなげると次の言葉になります。</p>
         <div class="final-answer">${combinedAnswer}</div>
         <footer>※ 現在は仮問です。本番用の問題に差し替えてもこの合成ロジックを再利用できます。</footer>
       </div>


### PR DESCRIPTION
## Summary
- add a crossword puzzle data model featuring a SATOR square sample for puzzle 1
- render crossword grids with clue lists, selection logic, and completion checking alongside existing text puzzles
- style the crossword grid, active cell highlighting, and clue list layout for the new UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daa2f0e3a48323899eea243e000a75