### PR TITLE
クロスワードに全マス自動入力ボタンを追加

### DIFF
--- a/docs/assets/main.js
+++ b/docs/assets/main.js
@@ -635,6 +635,9 @@ function renderCrosswordPuzzle(puzzle) {
         : "id=\"hint-button\" type=\"button\"";
     const hintText = hintRevealed ? puzzle.hint : "ヒントはまだ非公開です。";
     const hintClass = hintRevealed ? "hint hint--visible" : "hint";
+    const testFillButtonHtml = puzzle.id === 1
+        ? `<button id="crossword-fill-all" type="button" class="crossword-fill">(テスト) 全マス入力</button>`
+        : "";
     app.innerHTML = `
     <section class="app-shell">
       <h1>Hydrangea Riddles</h1>
@@ -677,6 +680,7 @@ function renderCrosswordPuzzle(puzzle) {
                 </ol>
               </div>
             </div>
+            ${testFillButtonHtml}
           </div>
         </div>
         ${feedbackHtml}
@@ -687,6 +691,7 @@ function renderCrosswordPuzzle(puzzle) {
     const entryInput = document.getElementById(`crossword-entry-${puzzle.id}`);
     const hintButton = document.getElementById("hint-button");
     const hintArea = document.getElementById("hint-area");
+    const fillAllButton = document.getElementById("crossword-fill-all");
     if (entryInput) {
         if (progress.activeCell) {
             const { row, col } = progress.activeCell;
@@ -732,6 +737,27 @@ function renderCrosswordPuzzle(puzzle) {
         }
         render();
     };
+    fillAllButton === null || fillAllButton === void 0 ? void 0 : fillAllButton.addEventListener("click", () => {
+        for (let row = 0; row < puzzle.grid.length; row += 1) {
+            for (let col = 0; col < puzzle.grid[row].length; col += 1) {
+                const solution = puzzle.grid[row][col];
+                if (!solution) {
+                    continue;
+                }
+                progress.entries[row][col] = solution.toUpperCase();
+            }
+        }
+        const firstEditable = findFirstEditableCell(puzzle);
+        progress.activeCell = firstEditable;
+        if (firstEditable) {
+            syncActiveClue(progress, puzzle, firstEditable);
+        }
+        resetFeedback();
+        handleCompletion();
+        if (!isCrosswordSolved(puzzle, progress)) {
+            render();
+        }
+    });
     const handleInput = (event) => {
         if (!(event.target instanceof HTMLInputElement)) {
             return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -790,6 +790,10 @@ function renderCrosswordPuzzle(puzzle: CrosswordPuzzle): void {
     : "id=\"hint-button\" type=\"button\"";
   const hintText = hintRevealed ? puzzle.hint : "ヒントはまだ非公開です。";
   const hintClass = hintRevealed ? "hint hint--visible" : "hint";
+  const testFillButtonHtml =
+    puzzle.id === 1
+      ? `<button id="crossword-fill-all" type="button" class="crossword-fill">(テスト) 全マス入力</button>`
+      : "";
 
   app.innerHTML = `
     <section class="app-shell">
@@ -833,6 +837,7 @@ function renderCrosswordPuzzle(puzzle: CrosswordPuzzle): void {
                 </ol>
               </div>
             </div>
+            ${testFillButtonHtml}
           </div>
         </div>
         ${feedbackHtml}
@@ -844,6 +849,7 @@ function renderCrosswordPuzzle(puzzle: CrosswordPuzzle): void {
   const entryInput = document.getElementById(`crossword-entry-${puzzle.id}`) as HTMLInputElement | null;
   const hintButton = document.getElementById("hint-button");
   const hintArea = document.getElementById("hint-area");
+  const fillAllButton = document.getElementById("crossword-fill-all");
 
   if (entryInput) {
     if (progress.activeCell) {
@@ -892,6 +898,28 @@ function renderCrosswordPuzzle(puzzle: CrosswordPuzzle): void {
     }
     render();
   };
+
+  fillAllButton?.addEventListener("click", () => {
+    for (let row = 0; row < puzzle.grid.length; row += 1) {
+      for (let col = 0; col < puzzle.grid[row].length; col += 1) {
+        const solution = puzzle.grid[row][col];
+        if (!solution) {
+          continue;
+        }
+        progress.entries[row][col] = solution.toUpperCase();
+      }
+    }
+    const firstEditable = findFirstEditableCell(puzzle);
+    progress.activeCell = firstEditable;
+    if (firstEditable) {
+      syncActiveClue(progress, puzzle, firstEditable);
+    }
+    resetFeedback();
+    handleCompletion();
+    if (!isCrosswordSolved(puzzle, progress)) {
+      render();
+    }
+  });
 
   const handleInput = (event: Event): void => {
     if (!(event.target instanceof HTMLInputElement)) {


### PR DESCRIPTION
## 概要
- 問1のクロスワードにテスト用の全マス入力ボタンを追加
- ボタン押下でグリッドを正解で埋めて自動的に判定する処理を実装
- ビルド成果物を更新

## 動作確認
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db33ef49808323bd65aa566e66b632