### PR TITLE
クロスワード確認フローの改善

### DIFF
--- a/docs/assets/main.js
+++ b/docs/assets/main.js
@@ -636,7 +636,12 @@ function renderCrosswordPuzzle(puzzle) {
     const hintText = hintRevealed ? puzzle.hint : "ヒントはまだ非公開です。";
     const hintClass = hintRevealed ? "hint hint--visible" : "hint";
     const testFillButtonHtml = puzzle.id === 1
-        ? `<button id="crossword-fill-all" type="button" class="crossword-fill">(テスト) 全マス入力</button>`
+        ? `
+          <div class="crossword-test-controls">
+            <button id="crossword-fill-all" type="button" class="crossword-fill">全マス入力</button>
+            <button id="crossword-confirm" type="button" class="crossword-confirm">答えを確定する</button>
+          </div>
+        `
         : "";
     app.innerHTML = `
     <section class="app-shell">
@@ -692,6 +697,7 @@ function renderCrosswordPuzzle(puzzle) {
     const hintButton = document.getElementById("hint-button");
     const hintArea = document.getElementById("hint-area");
     const fillAllButton = document.getElementById("crossword-fill-all");
+    const confirmButton = document.getElementById("crossword-confirm");
     if (entryInput) {
         if (progress.activeCell) {
             const { row, col } = progress.activeCell;
@@ -752,11 +758,22 @@ function renderCrosswordPuzzle(puzzle) {
         if (firstEditable) {
             syncActiveClue(progress, puzzle, firstEditable);
         }
-        resetFeedback();
-        handleCompletion();
-        if (!isCrosswordSolved(puzzle, progress)) {
-            render();
+        state.feedback = {
+            kind: "success",
+            message: "全マスを仮入力しました。「答えを確定する」を押してください。",
+        };
+        render();
+    });
+    confirmButton === null || confirmButton === void 0 ? void 0 : confirmButton.addEventListener("click", () => {
+        if (isCrosswordSolved(puzzle, progress)) {
+            handleCompletion();
+            return;
         }
+        state.feedback = {
+            kind: "error",
+            message: "まだ未完成です。入力内容を見直してから『答えを確定する』を押してください。",
+        };
+        render();
     });
     const handleInput = (event) => {
         if (!(event.target instanceof HTMLInputElement)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -792,7 +792,12 @@ function renderCrosswordPuzzle(puzzle: CrosswordPuzzle): void {
   const hintClass = hintRevealed ? "hint hint--visible" : "hint";
   const testFillButtonHtml =
     puzzle.id === 1
-      ? `<button id="crossword-fill-all" type="button" class="crossword-fill">(テスト) 全マス入力</button>`
+      ? `
+          <div class="crossword-test-controls">
+            <button id="crossword-fill-all" type="button" class="crossword-fill">全マス入力</button>
+            <button id="crossword-confirm" type="button" class="crossword-confirm">答えを確定する</button>
+          </div>
+        `
       : "";
 
   app.innerHTML = `
@@ -850,6 +855,7 @@ function renderCrosswordPuzzle(puzzle: CrosswordPuzzle): void {
   const hintButton = document.getElementById("hint-button");
   const hintArea = document.getElementById("hint-area");
   const fillAllButton = document.getElementById("crossword-fill-all");
+  const confirmButton = document.getElementById("crossword-confirm");
 
   if (entryInput) {
     if (progress.activeCell) {
@@ -914,11 +920,23 @@ function renderCrosswordPuzzle(puzzle: CrosswordPuzzle): void {
     if (firstEditable) {
       syncActiveClue(progress, puzzle, firstEditable);
     }
-    resetFeedback();
-    handleCompletion();
-    if (!isCrosswordSolved(puzzle, progress)) {
-      render();
+    state.feedback = {
+      kind: "success",
+      message: "全マスを仮入力しました。「答えを確定する」を押してください。",
+    };
+    render();
+  });
+
+  confirmButton?.addEventListener("click", () => {
+    if (isCrosswordSolved(puzzle, progress)) {
+      handleCompletion();
+      return;
     }
+    state.feedback = {
+      kind: "error",
+      message: "まだ未完成です。入力内容を見直してから『答えを確定する』を押してください。",
+    };
+    render();
   });
 
   const handleInput = (event: Event): void => {


### PR DESCRIPTION
## 概要
- 問1のテスト入力UIを全マス入力と答え確定ボタンを含むコンテナに変更
- 確認ボタンで進捗の正答判定を行い、正解時は完了処理を呼び出し、未完成時はエラーフィードバックを表示
- 全マス入力ボタンは盤面を埋めた後に確認を促すフィードバックを出すよう調整
- ビルドを実行して docs/assets/main.js を更新

## テスト
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db36afda5883239a8c0e1aec692fd6