### PR TITLE
画面タイトルの文字化けを修正

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>“ä‰ğ‚«ƒAƒvƒŠ | Hydrangea</title>
+  <title>è¬è§£ãã‚¢ãƒ—ãƒª | Hydrangea</title>
   <link rel="stylesheet" href="./styles.css">
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,6 @@
   <title>Hydrangea Puzzle</title>
 </head>
 <body>
-  <p><a href="./docs/index.html">Hydrangea Puzzle</a> ‚ÉˆÚ“®‚µ‚Ä‚¢‚Ü‚·...</p>
+  <p><a href="./docs/index.html">Hydrangea Puzzle</a> ã«ç§»å‹•ã—ã¦ã„ã¾ã™...</p>
 </body>
 </html>


### PR DESCRIPTION
## 概要
- docs/index.html を UTF-8 化し、タイトルを「謎解きアプリ | Hydrangea」に修正
- ルートの index.html にある案内文も UTF-8 に揃え、日本語メッセージを正しく表示

## テスト
- 未実施

------
https://chatgpt.com/codex/tasks/task_e_68db3d5cb90c8323b8e5228af8823ea5