### PR TITLE
クロスワード再訪時の再描画抑止

### DIFF
--- a/docs/assets/main.js
+++ b/docs/assets/main.js
@@ -727,8 +727,13 @@ function renderCrosswordPuzzle(puzzle) {
             return;
         }
         const currentIndex = state.currentPuzzleIndex;
-        const previousMax = state.maxUnlockedPuzzleIndex;
         const nextIndex = Math.min(currentIndex + 1, puzzles.length);
+        const alreadyFinalized = state.submittedAnswers[currentIndex] === puzzle.finalAnswer &&
+            state.maxUnlockedPuzzleIndex >= nextIndex;
+        if (alreadyFinalized) {
+            return;
+        }
+        const previousMax = state.maxUnlockedPuzzleIndex;
         state.submittedAnswers[currentIndex] = puzzle.finalAnswer;
         state.maxUnlockedPuzzleIndex = Math.max(previousMax, nextIndex);
         const unlockedNewPuzzle = nextIndex > previousMax;

--- a/src/main.ts
+++ b/src/main.ts
@@ -888,8 +888,14 @@ function renderCrosswordPuzzle(puzzle: CrosswordPuzzle): void {
       return;
     }
     const currentIndex = state.currentPuzzleIndex;
-    const previousMax = state.maxUnlockedPuzzleIndex;
     const nextIndex = Math.min(currentIndex + 1, puzzles.length);
+    const alreadyFinalized =
+      state.submittedAnswers[currentIndex] === puzzle.finalAnswer &&
+      state.maxUnlockedPuzzleIndex >= nextIndex;
+    if (alreadyFinalized) {
+      return;
+    }
+    const previousMax = state.maxUnlockedPuzzleIndex;
     state.submittedAnswers[currentIndex] = puzzle.finalAnswer;
     state.maxUnlockedPuzzleIndex = Math.max(previousMax, nextIndex);
     const unlockedNewPuzzle = nextIndex > previousMax;


### PR DESCRIPTION
## 概要
- クロスワードの完了処理にガード条件を追加し、既に最終回答を登録済みの場合は再描画を避けるようにしました。
- TypeScript の変更に合わせてビルド済みの JavaScript を更新しました。

## テスト
- npm run build
- Playwright を用いたブラウザ確認（初回クリアで次の問題・最終画面に遷移できること／再訪時に RangeError が発生しないこと）


------
https://chatgpt.com/codex/tasks/task_e_68db3e053b688323bdbd7b5f758f1ac7