### PR TITLE
フォーム入力とボタンの縦方向レイアウト修正

### DIFF
--- a/docs/assets/main.js
+++ b/docs/assets/main.js
@@ -161,7 +161,7 @@ function renderLogin() {
       <h1>Hydrangea Lab</h1>
       <div class="puzzle-card">
         <p>この謎解きは特定の参加者のみアクセスできます。パスワードを入力してください。</p>
-        <form id="login-form">
+        <form id="login-form" class="form-stack">
           <label for="password-input">パスワード</label>
           <input
             id="password-input"
@@ -302,14 +302,16 @@ function renderTextPuzzle(puzzle) {
           <button ${hintButtonAttrs}>ヒントを見る</button>
           <div id="hint-area" class="${hintClass}">${hintText}</div>
         </div>
-        <label for="answer-input-${puzzle.id}">回答</label>
-        <input
-          id="answer-input-${puzzle.id}"
-          type="text"
-          placeholder="ここに回答を入力"
-          autocomplete="off"
-        />
-        <button id="answer-submit" type="button">回答を送信</button>
+        <div class="answer-stack">
+          <label for="answer-input-${puzzle.id}">回答</label>
+          <input
+            id="answer-input-${puzzle.id}"
+            type="text"
+            placeholder="ここに回答を入力"
+            autocomplete="off"
+          />
+          <button id="answer-submit" type="button">回答を送信</button>
+        </div>
         ${feedbackHtml}
         ${paginationControls}
       </div>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,4 +1,8 @@
 /* Hydrangea puzzle app styles */
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 :root {
   color-scheme: light dark;
   --bg: #0c0c0f;
@@ -31,6 +35,7 @@ body {
   align-items: flex-start;
   justify-content: center;
   padding: var(--space-6) var(--space-4);
+  overflow-x: hidden;
 }
 
 .app-shell {
@@ -79,6 +84,22 @@ label {
   margin-bottom: var(--space-3);
   font-weight: 600;
   letter-spacing: 0.04em;
+}
+
+.form-stack,
+.answer-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.form-stack label,
+.answer-stack label {
+  margin-bottom: 0;
+}
+
+.answer-stack {
+  margin-top: var(--space-5);
 }
 
 input[type="password"],

--- a/src/main.ts
+++ b/src/main.ts
@@ -234,7 +234,7 @@ function renderLogin(): void {
       <h1>Hydrangea Lab</h1>
       <div class="puzzle-card">
         <p>この謎解きは特定の参加者のみアクセスできます。パスワードを入力してください。</p>
-        <form id="login-form">
+        <form id="login-form" class="form-stack">
           <label for="password-input">パスワード</label>
           <input
             id="password-input"
@@ -389,14 +389,16 @@ function renderTextPuzzle(puzzle: TextPuzzle): void {
           <button ${hintButtonAttrs}>ヒントを見る</button>
           <div id="hint-area" class="${hintClass}">${hintText}</div>
         </div>
-        <label for="answer-input-${puzzle.id}">回答</label>
-        <input
-          id="answer-input-${puzzle.id}"
-          type="text"
-          placeholder="ここに回答を入力"
-          autocomplete="off"
-        />
-        <button id="answer-submit" type="button">回答を送信</button>
+        <div class="answer-stack">
+          <label for="answer-input-${puzzle.id}">回答</label>
+          <input
+            id="answer-input-${puzzle.id}"
+            type="text"
+            placeholder="ここに回答を入力"
+            autocomplete="off"
+          />
+          <button id="answer-submit" type="button">回答を送信</button>
+        </div>
         ${feedbackHtml}
         ${paginationControls}
       </div>


### PR DESCRIPTION
## 概要
- ログインフォームと回答入力のレイアウトを縦方向のスタック構造に変更し、入力欄とボタンの間隔を調整しました。
- スタック用のスタイルを追加してラベルとフォーム要素の余白を統一しました。
- TypeScript の変更に合わせてビルド済みアセットを更新しました。

## テスト
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68db93175208832385572d6289593d47